### PR TITLE
fix: Fix race condition with temp_file names

### DIFF
--- a/sling/__init__.py
+++ b/sling/__init__.py
@@ -1,5 +1,5 @@
 
-import os, sys, tempfile, time, json, platform
+import os, sys, tempfile, uuid, json, platform
 from subprocess import PIPE, Popen, STDOUT
 from typing import Iterable, List, Union
 from json import JSONEncoder
@@ -157,9 +157,9 @@ class Sling:
   def _prep_cmd(self):
 
     # generate temp file
-    ts = time.time_ns()
+    uid = uuid.uuid4()
     temp_dir = tempfile.gettempdir()
-    self.temp_file = os.path.join(temp_dir, f'sling-cfg-{ts}.json')
+    self.temp_file = os.path.join(temp_dir, f'sling-cfg-{uid}.json')
 
     # dump config
     with open(self.temp_file, 'w') as file:


### PR DESCRIPTION
When executing several sling tasks in parallel, I ran into an issue where two tasks were trying to use the same file name and caused them to fail. It is probably extremely rare but using a uuid should ensure it doesn't happen again.