### PR TITLE
Add handling for an empty env arg when using the `run` method.

### DIFF
--- a/sling/__init__.py
+++ b/sling/__init__.py
@@ -234,7 +234,9 @@ class Sling:
     lines = []
     try:
       for k,v in os.environ.items():
-        env[k] = env.get(k, v)
+        if not env:
+	  env = {}
+	env[k] = env.get(k, v)
 
       for line in _exec_cmd(cmd, env=env, stdin=stdin):
         if return_output:


### PR DESCRIPTION
Fixes #4 

When using the `run` method, if the `env` arg is not set an `AttributeError` occurs. 

The issue can be shown with  the following snippet:

```
import os

env = None

for k, v in os.environ.items():
    env[k] = env.get(k, v)
```

Since there is no method `get` on `NoneType` the attribute error is raised.