### PR TITLE
Fix for progress log, encodings might fail

### DIFF
--- a/sling/sling/__init__.py
+++ b/sling/sling/__init__.py
@@ -510,7 +510,7 @@ def _exec_cmd(cmd, stdin=None, stdout=PIPE, stderr=STDOUT, env:dict=None):
   with Popen(cmd, shell=True, env=env, stdin=stdin, stdout=stdout, stderr=stderr) as proc:
     if stdout and stdout != STDOUT and proc.stdout:
       for line in proc.stdout:
-        line = str(line.strip(), 'utf-8')
+        line = str(line.strip(), 'utf-8', errors='replace')
         yield line
 
     proc.wait()


### PR DESCRIPTION
When slinging into MSSQL server with a German locale, decoding the log messages might fail, which crashes the python wrapper.

In my case, an Umlaut caused this:

```
    511 if stdout and stdout != STDOUT and proc.stdout:
    512   for line in proc.stdout:
--> 513     line = str(line.strip(), 'utf-8')
    514     yield line
    516 proc.wait()

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x81 in position 88: invalid start byte
```