### PR TITLE
publish wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release to PyPi
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'version override'     
+        description: 'version override'
         required: false
   repository_dispatch:
     types: [release-python]
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
-        
+
       - name: Pip Install
         run: |
-          pip install twine
-        
+          pip install build twine
+
       - name: Release sling-linux-amd64 to PyPi
         run: |
           export BASE_FOLDER=sling_base/sling-linux-amd64
@@ -60,8 +60,8 @@ jobs:
 
           cd sling_base/sling-linux-amd64
           pip install -e .
-          python setup.py sdist && twine upload --verbose --skip-existing dist/*
-        
+          python -m build && twine upload --verbose --skip-existing dist/*
+
       - name: Release sling-linux-arm64 to PyPi
         run: |
           export BASE_FOLDER=sling_base/sling-linux-arm64
@@ -86,13 +86,13 @@ jobs:
           then
                 echo $VERSION_OVERRIDE > $BIN_FOLDER/VERSION
           fi
-          
+
           cp README.md $BASE_FOLDER/
 
           cd $BASE_FOLDER
           pip install -e .
-          python setup.py sdist && twine upload --verbose --skip-existing dist/*
-        
+          python -m build && twine upload --verbose --skip-existing dist/*
+
       - name: Release sling-mac-amd64 to PyPi
         run: |
           export BASE_FOLDER=sling_base/sling-mac-amd64
@@ -117,13 +117,13 @@ jobs:
           then
                 echo $VERSION_OVERRIDE > $BIN_FOLDER/VERSION
           fi
-          
+
           cp README.md $BASE_FOLDER/
 
           cd $BASE_FOLDER
           pip install -e .
-          python setup.py sdist && twine upload --verbose --skip-existing dist/*
-        
+          python -m build && twine upload --verbose --skip-existing dist/*
+
       - name: Release sling-mac-arm64 to PyPi
         run: |
           export BASE_FOLDER=sling_base/sling-mac-arm64
@@ -148,13 +148,13 @@ jobs:
           then
                 echo $VERSION_OVERRIDE > $BIN_FOLDER/VERSION
           fi
-          
+
           cp README.md $BASE_FOLDER/
 
           cd $BASE_FOLDER
           pip install -e .
-          python setup.py sdist && twine upload --verbose --skip-existing dist/*
-        
+          python -m build && twine upload --verbose --skip-existing dist/*
+
       - name: Release sling-windows-amd64 to PyPi
         run: |
           export BASE_FOLDER=sling_base/sling-windows-amd64
@@ -179,13 +179,13 @@ jobs:
           then
                 echo $VERSION_OVERRIDE > $BIN_FOLDER/VERSION
           fi
-          
+
           cp README.md $BASE_FOLDER/
 
           cd $BASE_FOLDER
           pip install -e .
-          python setup.py sdist && twine upload --verbose --skip-existing dist/*
-        
+          python -m build && twine upload --verbose --skip-existing dist/*
+
       - name: Release sling to PyPi
         run: |
           export SLING_VERSION=$( sling_base/sling-linux-amd64/sling_linux_amd64/bin/sling-linux-amd64 --version | sed 's/Version: //')
@@ -194,9 +194,9 @@ jobs:
           then
                 echo $VERSION_OVERRIDE > sling/VERSION
           fi
-          
+
           cp README.md sling/
-          
+
           cd sling
           pip install -e .
-          python setup.py sdist && twine upload --verbose --skip-existing dist/*
+          python -m build && twine upload --verbose --skip-existing dist/*

--- a/sling/setup.py
+++ b/sling/setup.py
@@ -16,24 +16,14 @@ if readme_path.exists():
   with readme_path.open() as file:
     README = file.read()
 
-install_requires = []
-if platform.system() == 'Linux':
-  if platform.machine() == 'aarch64':
-    install_requires = [f'sling-linux-arm64=={SLING_VERSION}']
-  else:
-    install_requires = [f'sling-linux-amd64=={SLING_VERSION}']
-elif platform.system() == 'Windows':
-  if platform.machine() == 'ARM64':
-    install_requires = [f'sling-windows-arm64=={SLING_VERSION}']
-  else:
-    install_requires = [f'sling-windows-amd64=={SLING_VERSION}']
-elif platform.system() == 'Darwin':
-  if platform.machine() == 'arm64':
-    install_requires = [f'sling-mac-arm64=={SLING_VERSION}']
-  else:
-    install_requires = [f'sling-mac-amd64=={SLING_VERSION}']
-else:
-  raise Exception(f'platform "{platform.system()}" ({platform.system()}) not supported.')
+install_requires = [
+    f'sling-linux-arm64=={SLING_VERSION} ; platform_system=="Linux" and platform_machine=="aarch64"',
+    f'sling-linux-amd64=={SLING_VERSION} ; platform_system=="Linux" and platform_machine=="aarch64"',
+    f'sling-windows-arm64=={SLING_VERSION} ; platform_system=="Windows" and platform_machine=="ARM64"',
+    f'sling-windows-amd64=={SLING_VERSION} ; platform_system=="Windows" and platform_machine!="ARM64"',
+    f'sling-mac-arm64=={SLING_VERSION} ; platform_system=="Darwin" and platform_machine=="arm64"',
+    f'sling-mac-amd64=={SLING_VERSION} ; platform_system=="Darwin" and platform_machine!="arm64"',
+]
 
 setup(
   name='sling',


### PR DESCRIPTION
Direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Publish wheels.