### PR TITLE
Add print_output parameter to allow real time monitoring

### DIFF
--- a/sling/sling/__init__.py
+++ b/sling/sling/__init__.py
@@ -574,7 +574,7 @@ class Task:
 # conform to legacy module
 Sling = Task
 
-def _run(cmd: str, temp_file: str, return_output=False, print_output=True, env:dict=None, stdin=None):
+def _run(cmd: str, temp_file: str, return_output=False, print_output=False, env:dict=None, stdin=None):
   """
   Runs the task.
   
@@ -591,6 +591,8 @@ def _run(cmd: str, temp_file: str, return_output=False, print_output=True, env:d
     for line in _exec_cmd(cmd, env=env, stdin=stdin):
       if return_output:
         lines.append(line)
+      else:
+        print(line, flush=True)
       if print_output:
         print(line, flush=True)
     

--- a/sling/sling/__init__.py
+++ b/sling/sling/__init__.py
@@ -574,9 +574,13 @@ class Task:
 # conform to legacy module
 Sling = Task
 
-def _run(cmd: str, temp_file: str, return_output=False, env:dict=None, stdin=None):
+def _run(cmd: str, temp_file: str, return_output=False, print_output=True, env:dict=None, stdin=None):
   """
-  Runs the task. Use `return_output` as `True` to return the stdout+stderr output at end. `env` accepts a dictionary which defines the environment.
+  Runs the task.
+  
+  Use `return_output` as `True` to return the stdout+stderr output at end.
+  Use `print_output` as `True` to print to stdout as it runs.
+  `env` accepts a dictionary which defines the environment.
   """
   lines = []
   try:
@@ -587,7 +591,7 @@ def _run(cmd: str, temp_file: str, return_output=False, env:dict=None, stdin=Non
     for line in _exec_cmd(cmd, env=env, stdin=stdin):
       if return_output:
         lines.append(line)
-      else:
+      if print_output:
         print(line, flush=True)
     
     os.remove(temp_file)


### PR DESCRIPTION
This addresses something similar to #19.

The current behavior is that if return_output is True, nothing is printed to stdout as replication is occurring. Instead, the logs are returned once at the end.

[return_output is True in the Dagster integration](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-sling/dagster_sling/resources.py#L388), so there is no progress written to stdout until the replication finishes. If something is taking a long time, we have no visibility into what step it is on.

Now, if return_output and print_output are both true, we will be able to see sling's progress in stdout in real time.



The if / else statements are a bit counterintuitive (e.g. if return_output and print_output are both false, it still prints), but I wrote it that way to make sure existing behavior doesn't change unless someone uses the new parameter intentionally.
