### PR TITLE
Add missing hooks to dumped Replication config

### DIFF
--- a/sling/sling/__init__.py
+++ b/sling/sling/__init__.py
@@ -421,6 +421,7 @@ class Replication:
         defaults=self.defaults,
         streams=self.streams,
         env=self.env,
+        hooks=self.hooks,
       )
 
       json.dump(config, file, cls=JsonEncoder)


### PR DESCRIPTION
Example of not working hooks in replication:

```
import sling


env = {
    'SLING_PG': 'postgresql://postgres@localhost:5432/postgres?sslmode=disable',
}

defaults = {
    'mode': 'full-refresh',
    'object': 'public.{stream_table}_sync',
}

streams = {
    'public.test': sling.ReplicationStream(
        **defaults
    ),
}

hooks = {
    'start':  [{
        'type': 'query',
        'connection': 'SLING_PG',
        'query': 'create table public.test_hook (id int);'
    }]
}

replication = sling.Replication(source='SLING_PG', target='SLING_PG', streams=streams, debug=True, hooks=hooks)
replication.run(env=env)
```