### PR TITLE
fix: stream_arrow() deadlock — return reader before process.wait() (#38)

### DIFF
--- a/sling/sling/__init__.py
+++ b/sling/sling/__init__.py
@@ -542,6 +542,72 @@ class SlingError(Exception):
     pass
 
 
+class _ArrowProcessReader:
+    """Wraps a pyarrow RecordBatchStreamReader bound to a subprocess.
+
+    Iteration/read_all are delegated to the underlying reader. The subprocess is
+    only waited on (and its exit code checked) once the stream is exhausted or the
+    reader is closed — never before the reader is handed back. Waiting eagerly
+    deadlocks: the lazy reader has not drained stdout yet, so the subprocess blocks
+    writing to a full pipe while process.wait() blocks on the process.
+    """
+
+    def __init__(self, reader, process, stderr_lines, on_close=None):
+        self._reader = reader
+        self._process = process
+        self._stderr_lines = stderr_lines
+        self._on_close = on_close
+        self._finalized = False
+
+    def _finalize(self):
+        if self._finalized:
+            return
+        self._finalized = True
+        self._process.wait()
+        if self._on_close is not None:
+            self._on_close()
+        if self._process.returncode != 0:
+            stderr_output = '\n'.join(self._stderr_lines) if self._stderr_lines else "No stderr output captured"
+            raise SlingError(f"Sling command failed with return code: {self._process.returncode}\n{stderr_output}")
+
+    def read_next_batch(self):
+        try:
+            return self._reader.read_next_batch()
+        except StopIteration:
+            self._finalize()
+            raise
+
+    def __iter__(self):
+        for batch in self._reader:
+            yield batch
+        self._finalize()
+
+    def read_all(self):
+        table = self._reader.read_all()
+        self._finalize()
+        return table
+
+    @property
+    def schema(self):
+        return self._reader.schema
+
+    def close(self):
+        try:
+            self._reader.close()
+        finally:
+            self._finalize()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def __getattr__(self, name):
+        # delegate anything else (e.g. RecordBatchStreamReader internals)
+        return getattr(self._reader, name)
+
+
 class Sling:
     """
     Sling class that mirrors the sling CLI functionalities.
@@ -1415,23 +1481,25 @@ class Sling:
                 # Write input data directly in the main thread
                 self._write_input_data_sync(process.stdin, self.input)
             
-            # Handle output streaming
+            # Handle output streaming.
+            #
+            # The reader is lazy: it does not drain stdout until the caller iterates
+            # it. We must therefore hand it back BEFORE waiting on the process —
+            # waiting here deadlocks, because the subprocess blocks writing to a full
+            # stdout pipe that nothing is reading yet. Defer process.wait() + exit-code
+            # check to the wrapper, which runs them once the stream is exhausted/closed.
             try:
                 reader = self._read_output_stream_arrow(process.stdout)
-                return reader
-            
-            finally:
-                # Wait for process to complete
+            except Exception:
                 process.wait()
-
-                # Restore original stdout setting
                 self.stdout = original_stdout
-                
-                if process.returncode != 0:
-                    # Use collected stderr lines for error message
-                    stderr_output = '\n'.join(stderr_lines) if stderr_lines else "No stderr output captured"
-                    raise SlingError(f"Sling command failed with return code: {process.returncode}\n{stderr_output}")
-                    
+                raise
+
+            return _ArrowProcessReader(
+                reader, process, stderr_lines,
+                on_close=lambda: setattr(self, 'stdout', original_stdout),
+            )
+
         except Exception as e:
             if isinstance(e, SlingError):
                 raise

--- a/sling/tests/test_sling_class.py
+++ b/sling/tests/test_sling_class.py
@@ -612,8 +612,8 @@ class TestSlingArrowStreaming:
 
         reader = sling.stream_arrow()
 
-        # Check if it's a RecordBatchStreamReader
-        assert isinstance(reader, pa.ipc.RecordBatchStreamReader)
+        # reader proxies the RecordBatchStreamReader interface (read_all/iter/schema)
+        assert hasattr(reader, "read_all") and hasattr(reader, "schema")
 
         table = reader.read_all()
         assert table.num_rows == len(sample_data)
@@ -717,6 +717,32 @@ class TestSlingArrowStreaming:
         for i, expected in enumerate([50000.0, 60000.00009, 5500023.01111, 65000.0002, 58000.04]):
             actual = float(pydict['salary'][i])
             assert abs(actual - expected) < 0.001, f"Salary mismatch at index {i}: {actual} != {expected}"
+
+    def test_stream_arrow_iterates_without_deadlock(self, temp_dir, sample_data):
+        """Regression: stream_arrow must hand back the reader before waiting on the
+        process, and iterating batch-by-batch must not deadlock on the stdout pipe.
+
+        Previously stream_arrow ran process.wait() in a finally before returning the
+        lazy reader: the subprocess blocked writing to a full stdout pipe while
+        process.wait() blocked on the process -> hang. Enough rows are written here
+        that the data exceeds a single OS pipe buffer.
+        """
+        input_file = os.path.join(temp_dir, "many.csv")
+        fieldnames = ["id", "name", "age", "city", "salary", "created_at"]
+        with open(input_file, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            base = sample_data[0]
+            for i in range(50000):
+                row = dict(base); row["id"] = i; writer.writerow(row)
+
+        reader = Sling(src_conn=f"file://{input_file}").stream_arrow(print_output=False)
+
+        # iterate (the path that deadlocked) rather than read_all
+        total = 0
+        for batch in reader:
+            total += batch.num_rows
+        assert total == 50000
 
     @pytest.mark.skipif(not HAS_POLARS, reason="Polars is not installed")
     def test_stream_arrow_from_polars_input(self, temp_dir, sample_data):


### PR DESCRIPTION
Fixes #38.

## Problem

`Sling.stream_arrow()` deadlocks whenever the source produces more output than one OS pipe buffer (~64KB), and can hang even on small sources.

The reader was returned from inside a `try` whose `finally` ran `process.wait()`:

```python
try:
    reader = self._read_output_stream_arrow(process.stdout)
    return reader
finally:
    process.wait()   # runs before the return is delivered
```

`_read_output_stream_arrow` builds a **lazy** `pa.ipc.open_stream(process.stdout)` that hasn't drained stdout. Since `finally` runs before the caller receives the reader:

1. the subprocess fills the stdout pipe and blocks on `write()`,
2. nothing drains it (the caller never got the reader),
3. `process.wait()` waits for a process that can't exit → deadlock.

`stream()` is unaffected because it drains stdout line-by-line as a generator.

## Fix

Return the reader **before** waiting on the process. The new `_ArrowProcessReader` proxy hands the reader back immediately and defers `process.wait()` + exit-code check + stdout restore until the stream is exhausted (`StopIteration`), `read_all()` completes, or `close()`/context-exit is called. It delegates `read_next_batch`, `__iter__`, `read_all`, and `schema` to the underlying reader, and proxies anything else via `__getattr__`.

## Behaviour change

`stream_arrow()` now returns an `_ArrowProcessReader` rather than a raw `pa.ipc.RecordBatchStreamReader`. It is a duck-typed proxy (same `read_all`/`__iter__`/`read_next_batch`/`schema` surface, plus context-manager support), so existing usage — iterating, `read_all()`, reading `schema` — is unchanged. One existing test that asserted the exact class was updated to assert the interface.

## Tests

- `test_stream_arrow_iterates_without_deadlock` — writes a 50k-row CSV (exceeds one pipe buffer) and iterates the reader batch-by-batch (the path that previously hung).
- Existing `stream_arrow` tests pass (4 passed, 1 skipped[polars]).

## Verification

Reproduced the hang on `1.5.19.post1`, then confirmed the patched package returns the reader in ~2s and `read_all()`/iteration complete against both a SQL Server source and the 50k-row CSV.
